### PR TITLE
Fixed pillar example to set the default version correctly

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,5 +3,4 @@ nvm:
     install:
       - "0.8"
       - "0.10"
-    default:
-      - "0.10"
+    default: "0.10"


### PR DESCRIPTION
If setting the default as an array item, the formula fails because the alias command becomes (for version: stable): `nvm alias default ["stable"]`, which is invalid.
